### PR TITLE
Fixing association of trig elinks to RX for east vs west wagons

### DIFF
--- a/run_bert.py
+++ b/run_bert.py
@@ -214,7 +214,14 @@ class BERT(Test):
         
         link_names = {}
 
-        with open(Path(__file__).parent / 'static' /'txrx.json') as link_file:
+        orientation = ""
+
+        if self.subtype[:2] == "WE":
+            orientation = "_east"
+        elif self.subtype[:2] == "WW":
+            orrientation = "_west"
+
+        with open(Path(__file__).parent / 'static' /'txrx{}.json'.format(orientation)) as link_file:
 
             txrx = json.load(link_file)
             

--- a/static/txrx_east.json
+++ b/static/txrx_east.json
@@ -1,0 +1,27 @@
+{
+    "__description__": "This file is used to determine which TXs and RXs correspond to a given wagon elink. This is dependent on firmware version and may need to be updated if the firmware is updated.",
+    "TX": [
+        {"num": 0, "link": "CLK1"},
+        {"num": 1, "link": "CLK2"},
+        {"num": 2, "link": "CLK3"},
+        {"num": 4, "link": "DAQ0"},
+        {"num": 5, "link": "DAQ1"},
+        {"num": 6, "link": "DAQ2"},
+        {"num": 7, "link": "X_DAQ"}
+    ],
+    "RX": [
+        {"num": 0, "link": "TRIG6"},
+        {"num": 1, "link": "TRIG5"},
+        {"num": 2, "link": "TRIG4"},
+        {"num": 3, "link": "TRIG3"},
+        {"num": 4, "link": "TRIG2"},
+        {"num": 5, "link": "TRIG1"},
+        {"num": 6, "link": "TRIG0"},
+        {"num": 7, "link": "CTL1"},
+        {"num": 8, "link": "CTL2"},
+        {"num": 9, "link": "CTL3"},
+        {"num": 10, "link": ""},
+        {"num": 11, "link": ""},
+        {"num": 12, "link": ""}
+    ]
+}

--- a/static/txrx_west.json
+++ b/static/txrx_west.json
@@ -1,0 +1,27 @@
+{
+    "__description__": "This file is used to determine which TXs and RXs correspond to a given wagon elink. This is dependent on firmware version and may need to be updated if the firmware is updated.",
+    "TX": [
+        {"num": 0, "link": "CLK1"},
+        {"num": 1, "link": "CLK2"},
+        {"num": 2, "link": "CLK3"},
+        {"num": 4, "link": "DAQ0"},
+        {"num": 5, "link": "DAQ1"},
+        {"num": 6, "link": "DAQ2"},
+        {"num": 7, "link": "X_DAQ"}
+    ],
+    "RX": [
+        {"num": 0, "link": "TRIG0"},
+        {"num": 1, "link": "TRIG1"},
+        {"num": 2, "link": "TRIG2"},
+        {"num": 3, "link": "TRIG3"},
+        {"num": 4, "link": "TRIG4"},
+        {"num": 5, "link": "TRIG5"},
+        {"num": 6, "link": "TRIG6"},
+        {"num": 7, "link": "CTL1"},
+        {"num": 8, "link": "CTL2"},
+        {"num": 9, "link": "CTL3"},
+        {"num": 10, "link": ""},
+        {"num": 11, "link": ""},
+        {"num": 12, "link": ""}
+    ]
+}


### PR DESCRIPTION
The RX mapping of the engine trig elinks flips order between east and west wagons. 
- For west wagons, RX 0->6 correspond with Eng Trig Elink 0->6. 
- For east wagons, RX 0->6 correspond with Eng Trig Elink 6->0.

DAQ, CLK, and CTL all retain ordering between the two orientations.
BERT test updated to grab the correct json file (labeled either `txrx_east.json` or `txrx_west.json`) so that there are no more failures based on bad ordering.