### PR TITLE
Lowering passing criteria on BERT to accommodate clock eye opening di…

### DIFF
--- a/run_bert.py
+++ b/run_bert.py
@@ -75,7 +75,7 @@ class BERT(Test):
                 print("Bad scan found on RX {}".format(self.rxs[i]))
                 continue
             r['passed'] = True
-            if not r["Eye Opening"] >= 180 or r["Midpoint Errors"] != 0:
+            if not r["Eye Opening"] >= 170 or r["Midpoint Errors"] != 0:
                 r['passed'] = False
                 self.passed = False
             link_name = self.link_names[self.rxs[i]]


### PR DESCRIPTION
…fferences with Kria

Since moving to KRIA and driving signals at 1V2 rather than 1v8, we have seen false failures in for the clocks which do not have signal regenerated by crosspoint. So, the new passing criteria is 170 for the eye opening on this test stand. Further modifications to passing criteria may be made in future PRs.