### PR TITLE
Adding comments and passing criteria to test results, updated passing…

### DIFF
--- a/Test.py
+++ b/Test.py
@@ -15,9 +15,10 @@ class Test():
 
         self.conn = conn
 
-        time.sleep(1)
+        #time.sleep(1)
 
-        self.conn.send("Initializing a test")
+        if self.conn is not None:
+            self.conn.send("Initializing a test")
 
         # All information that should be provided from the GUI to every test
         try:
@@ -25,16 +26,19 @@ class Test():
             self.board_sn = info_dict['board_sn']
             self.tester = info_dict['tester']
         except:
-            self.conn.send("Please provide the name of the test, board serial number, and tester name")
+            if self.conn is not None:
+                self.conn.send("Please provide the name of the test, board serial number, and tester name")
 
         # Info that will be provided from running the test
         try:
-            self.passed, self.data = self.run_test(test_func, **kwargs)
+            self.passed, self.data, self.comments = self.run_test(test_func, **kwargs)
 
             # Package up results into a dictionary for parsing into a JSON
-            self.results = {'name': self.name, 'board_sn': self.board_sn, 'tester': self.tester, 'pass': self.passed, 'data': self.data}
+            self.results = {'name': self.name, 'board_sn': self.board_sn, 'tester': self.tester, 'pass': self.passed, 'data': self.data, 'comments': self.comments}
 
-            self.conn.send(self.dump_results())
+            
+            if self.conn is not None:
+                self.conn.send(self.dump_results())
             #self.save_results()
 
             self.send_results()
@@ -43,8 +47,9 @@ class Test():
 
             print(f"Encountered exception when running test: {e}")
            
-            self.conn.send(f'Issue running test "{info_dict["name"]}". Try rerunning')
-            self.conn.send("Exit.")
+            if self.conn is not None:
+                self.conn.send(f'Issue running test "{info_dict["name"]}". Try rerunning')
+                self.conn.send("Exit.")
 
     # Dump results in JSON format for uploading to the database
     def dump_results(self):
@@ -56,7 +61,8 @@ class Test():
         if not os.path.exists("/home/HGCAL_dev/sw/WagonTesting/jsons/{}".format(self.name.replace(" ", ""))):
             os.makedirs("/home/HGCAL_dev/sw/WagonTesting/jsons/{}".format(self.name.replace(" ", "")))
 
-        self.conn.send("\nSaving results...\n")
+        if self.conn is not None:
+            self.conn.send("\nSaving results...\n")
         with open("/home/HGCAL_dev/sw/WagonTesting/jsons/{0}/{0}_{1}.json".format(self.name.replace(" ",""), self.board_sn), "w") as f:
             f.write(self.dump_results())
 
@@ -64,17 +70,21 @@ class Test():
 
     # Get results as a python dictionary
     def get_results(self):
-        self.conn.send(self.results)
+
+        if self.conn is not None:
+            self.conn.send(self.results)
         return self.results
 
     # Send results via the PUB Server
     def send_results(self):
-        self.conn.send(self.dump_results())
+        if self.conn is not None:
+            self.conn.send(self.dump_results())
 
     # Function for running your test, kwargs must agree with defined kwargs for your test
     # This function assumes that the output of the test will be the pass/fail condition (bool)
     # and a dictionary (of any depth) containing the extra data to store for the test
     def run_test(self, test_func, **kwargs):
-        self.conn.send("Running the test: run_test")
+        if self.conn is not None:
+            self.conn.send("Running the test: run_test")
         return test_func(**kwargs)
 

--- a/fit_bert.py
+++ b/fit_bert.py
@@ -4,21 +4,26 @@ import sys
 #mpl.use('tkagg')
 
 from math import sqrt, isnan
+import numpy as np
 #import matplotlib.pyplot as plt
-from scipy.optimize import curve_fit
+#from scipy.optimize import curve_fit
+
+import lmfit
 from scipy.special import erf
+from scipy.signal import find_peaks
 from pandas import read_csv
 from argparse import ArgumentParser
 
 class FitData:
     
-    def __init__(self, path_data, conn, scan_idx=-1, num_scan=-1, scan_mask=None, iskip=1):
+    def __init__(self, path_data, conn, scan_idx=-1, num_scan=-1, scan_mask=None, iskip=1, prbs_len=30000000, run=True):
         self.all_data = read_csv(path_data, header=None, delim_whitespace=True)
         self.path = path_data
         self.num_scan = num_scan        
         self.scan_idx = scan_idx
         self.conn = conn
         self.iskip = iskip
+        self.prbs_len = prbs_len
 
         if self.scan_idx is not -1:
             self.single_scan = self.get_one_scan(self.scan_idx)
@@ -27,7 +32,8 @@ class FitData:
             self.results = []
             for i,mask_val in enumerate(scan_mask):
                 if mask_val:
-                    self.conn.send("Fitting BER Scan #{}...".format(i))
+                    if self.conn is not None:
+                        self.conn.send("Fitting BER Scan #{}...".format(i))
                     i_scan = self.get_one_scan(i)
                     res = self.do_fit(i, i_scan)
                     if res is None:
@@ -43,40 +49,45 @@ class FitData:
     def get_results(self):
         return self.results
 
-    def do_fit(self, scan_idx, scan):
+    def do_fit(self, scan_idx, scan, return_scan=False):
         self.guess = []
 
         scan = self.invert_check(scan)
         #scan, good_scan = self.wrap_check(scan)
-        maxes = self.get_peaks(scan)
+        maxes = self.get_peaks_temp(scan)
 
         if len(maxes) > 2:
             maxes = maxes[:2]
 
         if len(maxes) < 2:
-            self.conn.send("Bad scan with index {}, double check that this line is connected".format(scan_idx))
+            if self.conn is not None:
+                self.conn.send("Bad scan with index {}, double check that this line is connected".format(scan_idx))
             return {"Eye Opening": -999, "Midpoint": -999, "Midpoint Errors": -999}
 
         #if not good_scan:
         #    self.conn.send("Bad scan with index {}, double check that this line is connected".format(scan_idx))
         #    return {"Eye Opening": -999, "Midpoint": -999, "Midpoint Errors": -999}
 
-        guess = self.get_guess(scan, maxes)
-        #xmin, xmax = self.get_window(scan)
         xmin, xmax = maxes
-        scan = self.trim_scan(scan, xmin, xmax)
-        scan = self.pad_scan(scan, 50)
+        #xmin, xmax = self.get_window(scan)
+        scan, xmin, xmax = self.trim_scan(scan, xmin, xmax)
+        maxes = (xmin, xmax)
+        scan = self.pad_scan(scan, 100)
+        guess = self.get_guess(scan, maxes)
 
         i_fit = 0
 
-        fit_params = self.fit_scan(scan, i_fit, guess)
+        self.fit_params = self.fit_scan(scan, i_fit, guess)
 
-        if fit_params is not None:
-            data = self.plot_scan(scan, scan_idx, fit_params)
+        if self.fit_params is not None:
+            data = self.plot_scan(scan, scan_idx, self.fit_params)
         else:
             return None       
  
-        return data
+        if return_scan:
+            return data, scan
+        else:
+            return data
 
     def invert_check(self, scan):
         # If the line needs to be inverted, we can simply invert the data by subtraction
@@ -84,8 +95,10 @@ class FitData:
         temp_ydata = scan["ydata"]
         temp_xdata = scan["xdata"]
 
-        if 240000008 in temp_ydata:
-            temp_ydata = [240000008 - x for x in temp_ydata]
+        #if 240000008 in temp_ydata:
+        if (self.prbs_len + 1) * 8 in temp_ydata:
+            #temp_ydata = [240000008 - x for x in temp_ydata]
+            temp_ydata = [((self.prbs_len + 1) * 8) - x for x in temp_ydata]
 
         scan['ydata'] = temp_ydata
         scan['xdata'] = temp_xdata
@@ -147,14 +160,38 @@ class FitData:
 
     def plot_scan(self, scan, scan_idx, fit_params):
         x1, w1, TD1, x2, w2, TD2 = fit_params
+        mid_err = 0
 
-        width = round(x2 - x1)
-        mid = self.iskip*round((x2+x1)/(2*self.iskip))
-        if mid > 0 and mid < 499:
-            mid_err = scan["ydata"][scan['xdata'].index(int(mid))]
-        else:
-            mid_err = -1
+        x = np.array(scan['xdata'])
+        data = np.array(scan['ydata'])
 
+        y = self.fit_func(x, x1, w1, TD1, x2, w2, TD2)
+
+        data = data.astype(float)
+        y = y.astype(float)
+
+        data /= data.max() * 2
+        y /= y.max() * 2
+
+        y_sumres = y[y<0.001]
+        data_sumres = data[y<0.001]
+
+        sum_res = np.sum(abs(data_sumres - y_sumres))
+
+        ui = np.count_nonzero((x <= 0.5) & (x >=-0.5))
+        eo_fit = np.count_nonzero(y < 1e-12)
+        eo_data = np.count_nonzero(data < 1e-12)
+
+        eo_fit /= float(ui)
+        eo_data /= float(ui)
+
+        #width = x2 - x1
+        #mid_idx = round((scan['xdata'].index(x2)+scan['xdata'].index(x1))/2)
+        #print(mid)
+        #if mid > 0 and mid < 499:
+        #    mid_err = scan["ydata"][mid]
+        #else:
+        #    mid_err = -1
 
         #fig, axs = plt.subplots(2, gridspec_kw={'height_ratios': [2, 1]})
         #axs[0].scatter(scan['xdata'], scan['ydata'], label="BERT Data", s=10)
@@ -172,8 +209,15 @@ class FitData:
         #axs[0].set_title("Eye-Opening Width: {}".format(round(x2 - x1, 1)))
         #self.plot_residuals(scan, fit_params, axs[1])
         #plt.savefig("figures/{}_elink{}.png".format(self.path.split("/")[1][:-4], scan_idx))
-        
-        return {"Eye Opening": round(x2-x1), "Midpoint": round((x2+x1)/2), "Midpoint Errors": mid_err}
+       
+        results = {
+            'Fit Eye Opening': round(eo_fit, 3),
+            'Data Eye Opening': round(eo_data, 3),
+            'Fit Quality': round(float(sum_res), 4),
+        }
+
+        #return {"Eye Opening": round(x2-x1), "Midpoint": round((x2+x1)/2), "Midpoint Errors": mid_err}
+        return results
 
 
     def plot_residuals(self, scan, fit_params, ax):
@@ -184,6 +228,12 @@ class FitData:
                 val = 0
             res.append(val)
         ax.scatter(scan['xdata'], res, s=10)
+
+    def get_peaks_temp(self, scan):
+
+        peaks = find_peaks(scan['ydata'], width=20)[0]
+
+        return peaks
 
     def get_peaks(self, scan):
         
@@ -201,7 +251,6 @@ class FitData:
             if one_back <= y and two_back <= y and one_forward <= y and two_forward <= y and y != 0:
                 if x-self.iskip not in maxes and x-2*self.iskip not in maxes: 
                     maxes.append(x)
-        print(maxes)
         return maxes            
 
 
@@ -220,12 +269,20 @@ class FitData:
     def trim_scan(self, scan, xmin, xmax):
         min_idx = scan['xdata'].index(xmin)
         max_idx = scan['xdata'].index(xmax)
-        return {'xdata': scan['xdata'][min_idx:max_idx], 'ydata': scan['ydata'][min_idx:max_idx]}
 
+        #return {'xdata': scan['xdata'][min_idx:max_idx], 'ydata': scan['ydata'][min_idx:max_idx]}
+        temp = {'xdata': scan['xdata'][min_idx:max_idx], 'ydata': scan['ydata'][min_idx:max_idx]}
+        temp_x =  np.array(temp['xdata'])
+        temp_x = temp_x - temp_x.mean()
+        temp_x = temp_x / (temp_x.max()*2)
+        temp_x = list(temp_x)
+        temp['xdata'] = temp_x
+
+        return temp, min(temp['xdata']), max(temp['xdata'])
     
     def pad_scan(self, scan, pad):
 
-        iskip = scan['xdata'][1] - scan['xdata'][0]
+        self.iskip = scan['xdata'][1] - scan['xdata'][0]
 
         start = scan['xdata'][0]
         end = scan['xdata'][-1]
@@ -233,8 +290,8 @@ class FitData:
         front_y_padding = [max(scan['ydata'][:len(scan['ydata'])//2]) for i in range(pad)]
         back_y_padding = [max(scan['ydata'][len(scan['ydata'])//2:]) for i in range(pad)]
         
-        front_x_padding = [i for i in range(start - pad*iskip, start, iskip)]
-        back_x_padding = [i for i in range(end, end + pad*iskip, iskip)]
+        front_x_padding = [i for i in np.arange(start - pad*self.iskip, start, self.iskip)]
+        back_x_padding = [i for i in np.arange(end, end + pad*self.iskip, self.iskip)]
 
         return {'xdata': front_x_padding + scan['xdata'] + back_x_padding, 'ydata': front_y_padding + scan['ydata'] + back_y_padding}
 
@@ -243,20 +300,70 @@ class FitData:
         
 
     def fit_func(self, x, x1, w1, TD1, x2, w2, TD2):
-        return TD1 * (1 - (1 + erf((x - x1) / w1))/2) + TD2 * (1 + erf((x-x2) / w2))/2
+        return TD1 * (1 - (1 + erf((x - x1) / w1))/2) + TD2 * ((1 + erf((x-x2) / w2))/2)
 
     def fit_scan(self, scan, i_fit, guess):
-        try:
-            params, _ = curve_fit(self.fit_func, scan['xdata'], scan['ydata'], p0 = guess, maxfev=5000)        
-        except:
-            print("Bad Scan, moving to next")
-            return None
+        #try:
+        #params, _ = curve_fit(self.fit_func, scan['xdata'], scan['ydata'], p0 = guess, sigma=1/np.sqrt(scan['ydata']), maxfev=5000)        
+        model = lmfit.Model(self.fit_func)
+        params = model.make_params(x1=1, w1=1, TD1=1, x2=1, w2=1, TD2=1)
+
+        params['x1'].value = guess[0]
+        params['x1'].min = -1.0
+        params['x1'].max = 0.0
+
+        params['w1'].value = 0.01
+        params['w1'].min = 0.001
+        params['w1'].max = 0.1
+
+        params['TD1'].value = guess[2]
+        params['TD1'].min = guess[2] / 2
+        params['TD1'].max = guess[2] * 2
+
+        params['x2'].value = guess[3]
+        params['x2'].min = 0.0
+        params['x2'].max = 1.0
+        
+        params['w2'].value = 0.01
+        params['w2'].min = 0.001 
+        params['w2'].max = 0.1
+
+        params['TD2'].value = guess[5]
+        params['TD2'].min = guess[5] / 2
+        params['TD2'].max = guess[5] * 2
+
+        y_arr = np.array(scan['ydata'])
+
+        #weights = np.ones_like(y_arr)
+        #weights = weights * ((y_arr == y_arr[0]) | (y_arr == y_arr[-1]) | (y_arr <= 0.001 * y_arr.max()))
+        #weights[weights == np.inf] = 1
+
+        mask = ((y_arr == y_arr[0]) | (y_arr == y_arr[-1]) | (y_arr <= 0.001 * y_arr.max()))
+
+        fit_x = np.array(scan['xdata'])[mask]
+        fit_y = np.array(scan['ydata'])[mask]
+
+        #result = model.fit(scan['ydata'], params, x=scan['xdata'], weights=weights)
+        result = model.fit(fit_y, params, x=fit_x)
+
+        params = list(result.params.valuesdict().values())
+        #except:
+        #    print("Bad Scan, moving to next")
+        #    return None
         if i_fit == 0:
             return params
         else:
             params = self.fit_scan(scan, i_fit - 1, params)
 
         return params
+
+    def get_fit_params(self):
+        return self.fit_params
+
+    def get_scan(self):
+        return self.scan
+
+    #def fit_output(self,)
 
 #parser = ArgumentParser(description='Run fit on rising and falling edge for Wagon bit error rate data')
 #parser.add_argument('-i', '--input', action="store", type=str, dest="input", default="", help='Input path containing BER csv file')

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,26 +10,26 @@ from multiprocessing import Pipe
 from run_adc_self_test import ADC
 
 print("Starting")
-c1, c2 = Pipe()
+c1, c2 = None, None
 
 def run_tests(test_info):
    
     module = None
-    #print("Running ADC Self Test")
-    #ADC(c1, **test_info)
-    #print("Running General Resistance")
-    #gen_resist_test(c1, module = module, **test_info)
-    #print("Running ID Resistance Check")
-    #id_resist_test(c1, **test_info)
-    #print("Running IIC Check")
-    #IIC_Check(c1, module = module, **test_info)
-    #print("Running BERT")
-    BERT(c1, module = module, clock=True, **test_info) 
+    print("Running ADC Self Test")
+    ADC(c1, **test_info)
+    print("Running General Resistance")
+    gen_resist_test(c1, module = module, **test_info)
+    print("Running ID Resistance Check")
+    id_resist_test(c1, **test_info)
+    print("Running IIC Check")
+    IIC_Check(c1, module = module, **test_info)
+    print("Running BERT")
+    BERT(c1, module = module, clock=True, iskip=1, **test_info) 
 
 #sn = sys.argv[1]
 
 #test_info = {'board_sn': str(sn), 'tester': "Jocie"}
-test_info = {'board_sn': '320WE11A1000001', 'tester': "Bryan"}
+test_info = {'board_sn': '320WE30A1000001', 'tester': "Bryan"}
 run_tests(test_info)
 
 #print("Running tests for east wagon")

--- a/static/wagonConfig.json
+++ b/static/wagonConfig.json
@@ -1,6 +1,6 @@
 {
     "WE10A1": {
-        "NumMod": 1,
+        "IDResistor": 1000,
         "Mod1": {
             "Inputs": {
                 "0": {
@@ -44,7 +44,7 @@
         }
     },
     "WE10B1": {
-        "NumMod": 1,
+        "IDResistor": 6340,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -73,7 +73,7 @@
         }
     },
     "WE11A1": {
-        "NumMod": 2,
+        "IDResistor": 604,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -128,7 +128,7 @@
         }
     },
     "WE11B2": {
-        "NumMod": 2,
+        "IDResistor": 665,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -173,7 +173,7 @@
         }
     },
     "WE11C1": {
-        "NumMod": 2,
+        "IDResistor": 715,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -228,7 +228,7 @@
         }
     },
     "WE12A1": {
-        "NumMod": 3,
+        "IDResistor": 768,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -299,7 +299,7 @@
         }
     },
     "WE12B1": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -365,7 +365,7 @@
         }
     },
     "WE20A1": {
-        "NumMod": 2,
+        "IDResistor": 1200,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -440,7 +440,7 @@
         }
     },
     "WE20B1": {
-        "NumMod": 2,
+        "IDResistor": 1300,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -495,7 +495,7 @@
         }
     },
     "WE20E1": {
-        "NumMod": 2,
+        "IDResistor": 2670,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -545,7 +545,7 @@
         }
     },
     "WE21A1": {
-        "NumMod": 3,
+        "IDResistor": 2150,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -611,7 +611,7 @@
         }
     },
     "WE21B1": {
-        "NumMod": 3,
+        "IDResistor": 2370,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -677,7 +677,7 @@
         }
     },
     "WE21C1": {
-        "NumMod": 3,
+        "IDResistor": 2490,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -743,7 +743,7 @@
         }
     },
     "WE21C2": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -809,7 +809,7 @@
         }
     },
     "WE21C3": {
-        "NumMod": 3,
+        "IDResistor": 2870,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -875,7 +875,7 @@
         }
     },
     "WE21C4": {
-        "NumMod": 3,
+        "IDResistor": 3160,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -941,7 +941,7 @@
         }
     },
     "WE21C6": {
-        "NumMod": 3,
+        "IDResistor": 3650,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1007,7 +1007,7 @@
         }
     },
     "WE21D1": {
-        "NumMod": 3,
+        "IDResistor": 5110,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1037,7 +1037,7 @@
         }
     },
     "WE30A1": {
-        "NumMod": 3,
+        "IDResistor": 1500,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1103,7 +1103,7 @@
         }
     },
     "WE30A2": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1169,7 +1169,7 @@
         }
     },
     "WE30A3": {
-        "NumMod": 3,
+        "IDResistor": 1600,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1235,7 +1235,7 @@
         }
     },
     "WE31A1": {
-        "NumMod": 4,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1322,7 +1322,7 @@
         }
     },
     "WE31A3": {
-        "NumMod": 4,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1409,7 +1409,7 @@
         }
     },
     "WE40A1": {
-        "NumMod": 4,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1425,7 +1425,7 @@
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "XING0",
+                    "Eng_Elink": "TRIG5",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1441,12 +1441,12 @@
             },
             "Outputs": {
                 "3": {
-                    "Eng_Elink": "TRIG5",
+                    "Eng_Elink": "TRIG4",
                     "Mod_Elink": "TRIG0",
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "TRIG4",
+                    "Eng_Elink": "TRIG3",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1462,12 +1462,12 @@
             },
             "Outputs": {
                 "3": {
-                    "Eng_Elink": "TRIG3",
+                    "Eng_Elink": "TRIG2",
                     "Mod_Elink": "TRIG0",
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "TRIG2",
+                    "Eng_Elink": "TRIG1",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1483,12 +1483,12 @@
             },
             "Outputs": {
                 "3": {
-                    "Eng_Elink": "TRIG1",
+                    "Eng_Elink": "TRIG0",
                     "Mod_Elink": "TRIG0",
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "TRIG0",
+                    "Eng_Elink": "XING0",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1496,7 +1496,7 @@
         }
     },
     "WE40A2": {
-        "NumMod": 4,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1512,7 +1512,7 @@
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "XING0",
+                    "Eng_Elink": "TRIG5",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1528,12 +1528,12 @@
             },
             "Outputs": {
                 "3": {
-                    "Eng_Elink": "TRIG5",
+                    "Eng_Elink": "TRIG4",
                     "Mod_Elink": "TRIG0",
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "TRIG4",
+                    "Eng_Elink": "TRIG3",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1549,12 +1549,12 @@
             },
             "Outputs": {
                 "3": {
-                    "Eng_Elink": "TRIG3",
+                    "Eng_Elink": "TRIG2",
                     "Mod_Elink": "TRIG0",
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "TRIG2",
+                    "Eng_Elink": "TRIG1",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1570,12 +1570,12 @@
             },
             "Outputs": {
                 "3": {
-                    "Eng_Elink": "TRIG1",
+                    "Eng_Elink": "TRIG0",
                     "Mod_Elink": "TRIG0",
                     "Invert": 0
                 },
                 "2": {
-                    "Eng_Elink": "TRIG0",
+                    "Eng_Elink": "XING0",
                     "Mod_Elink": "TRIG1",
                     "Invert": 0
                 }
@@ -1583,7 +1583,7 @@
         }
     },
     "WW10A1": {
-        "NumMod": 1,
+        "IDResistor": 1100,
         "Mod1": {
             "Inputs": {
                 "0": {
@@ -1627,7 +1627,7 @@
         }
     },
     "WW11A1": {
-        "NumMod": 2,
+        "IDResistor": 820,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1682,7 +1682,7 @@
         }
     },
     "WW12A1": {
-        "NumMod": 3,
+        "IDResistor": 866,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1758,7 +1758,7 @@
         }
     },
     "WW12B1": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1824,7 +1824,7 @@
         }
     },
     "WW12C1": {
-        "NumMod": 3,
+        "IDResistor": 931,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1890,7 +1890,7 @@
         }
     },
     "WW20A1": {
-        "NumMod": 2,
+        "IDResistor": 1400,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -1965,7 +1965,7 @@
         }
     },
     "WW20B1": {
-        "NumMod": 2,
+        "IDResistor": 6810,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2015,7 +2015,7 @@
         }
     },
     "WW20C1": {
-        "NumMod": 2,
+        "IDResistor": 7150,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2075,7 +2075,7 @@
         }
     },
     "WW20D1": {
-        "NumMod": 2,
+        "IDResistor": 7500,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2130,7 +2130,7 @@
         }
     },
     "WW21A1": {
-        "NumMod": 3,
+        "IDResistor": 4530,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2201,7 +2201,7 @@
         }
     },
     "WW21B1": {
-        "NumMod": 3,
+        "IDResistor": 4320,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2267,7 +2267,7 @@
         }
     },
     "WW21C1": {
-        "NumMod": 3,
+        "IDResistor": 4120,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2338,7 +2338,7 @@
         }
     },
     "WW21D1": {
-        "NumMod": 3,
+        "IDResistor": 3830,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2404,7 +2404,7 @@
         }
     },
     "WW21E1": {
-        "NumMod": 3,
+        "IDResistor": 3320,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2470,7 +2470,7 @@
         }
     },
     "WW21E2": {
-        "NumMod": 3,
+        "IDResistor": 4750,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2536,7 +2536,7 @@
         }
     },
     "WW21E3": {
-        "NumMod": 3,
+        "IDResistor": 4930,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2602,7 +2602,7 @@
         }
     },
     "WW30A1": {
-        "NumMod": 3,
+        "IDResistor": 1800,
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2668,7 +2668,7 @@
         }
     },
     "WW30A2": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2734,7 +2734,7 @@
         }
     },
     "WW30B1": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {
@@ -2800,7 +2800,7 @@
         }
     },
     "WW30B2": {
-        "NumMod": 3,
+        "IDResistor": "Unknown",
         "Mod1": {
             "Inputs": {
                 "1": {

--- a/wagon_rtd.py
+++ b/wagon_rtd.py
@@ -13,8 +13,8 @@ def parse_ID(ID): #likely will come from an imported utility class, right now ju
     east = False
     return num_modules, east
 
-def check_value(value, target, tolerance):
-    passed = (target - tolerance < value < target + tolerance)
+def check_value(value, minimum, maximum):
+    passed = (minimum < value) and (value < maximum)
     if passed:
         message = "passed"
     else:
@@ -43,13 +43,18 @@ class module_ADS124:
         self.chip.wakeup()
         self.chip.reset()
         self.module = module + 1
-        self.targets = [[0.1,100],[0.1,100],[0.1,100],[0.1,100],[495,505]] #placeholder
+        self.passing_criteria = {
+            'min_resistance': 0.5,
+            'max_resistance': 70.,
+        }
         self.chip.reset_POR_flag()
         self.data={}
+        self.comments = []
 
     def get_resistances(self):
         try:
-            self.conn.send("testing chip for module " + str(self.module))
+            if self.conn is not None:
+                self.conn.send("testing chip for module " + str(self.module))
             all_passed = True
             self.chip.ref_config(1) # internal reference on (needed for IDAC)  
             self.chip.set_conv_delay(7)
@@ -65,17 +70,23 @@ class module_ADS124:
             print(resistance)
             print(self.chip.read_data())
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
             print("line %s resistance is %.2f ohms (27.4 + wire)" % (line, resistance[0]))
 
             self.chip.setup_mux(self.RTD, self.VMON_LVS) # measuring resistance between lines RTD and VMON_LVS  line = 'RTD -> VMON_LVS'                                  
             line = 'RTD -> VMON_LVS'                                  
             resistance = self.chip.read_volts(vref=2000,ave=4)
-            passed, message = check_value(resistance[0], self.targets[0][0], self.targets[0][1])
+            passed, message = check_value(resistance[0], self.passing_criteria['min_resistance'], self.passing_criteria['max_resistance'])
             if not passed:
                 all_passed = False
+                if resistance[0] <= self.passing_criteria['min_resistance']:
+                    self.comments.append('Short identified on module {} path {}'.format(self.module, line))
+                else:
+                    self.comments.append('Open identified on module {} path {}'.format(self.module, line))
             self.data[line] = resistance[0]
-            self.conn.send(("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message)))
+            if self.conn is not None:
+                self.conn.send(("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message)))
             print(("line %s resistance is %.2f ohms (1 + wire); %s" % (line, resistance[0], message)))
 
             self.chip.setup_mux(self.RTD, self.PWR_EN) # measuring resistance between lines RTD and PWR_EN
@@ -84,7 +95,8 @@ class module_ADS124:
             print(resistance)
             print(self.chip.read_data())
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
             print("line %s resistance is %.2f ohms (27.4 + wire)" % (line, resistance[0]))
 
             self.chip.setup_mux(self.RTD, self.PG_LDO) # measuring resistance between lines RTD and PG_LDO
@@ -93,7 +105,8 @@ class module_ADS124:
             print(resistance)
             print(self.chip.read_data())
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
             print("line %s resistance is %.2f ohms (27.4 + wire)" % (line, resistance[0]))
 
             self.chip.setup_mux(self.RTD, self.PG_DCDC) # measuring resistance between lines RTD and PG_DCDC
@@ -102,7 +115,8 @@ class module_ADS124:
             print(resistance)
             print(self.chip.read_data())
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
             print("line %s resistance is %.2f ohms (27.4 + wire)" % (line, resistance[0]))
 
             self.chip.setup_mux(self.RTD, self.ECON_RE_Hb) # measuring resistance between lines RTD and ECON_RE_Hb
@@ -111,7 +125,8 @@ class module_ADS124:
             print(resistance)
             print(self.chip.read_data())
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
             print("line %s resistance is %.2f ohms (27.4 + wire)" % (line, resistance[0]))
 
             self.chip.setup_mux(self.RTD, self.ECON_RE_Sb) # measuring resistance between lines RTD and ECON_RE_Sb
@@ -120,37 +135,53 @@ class module_ADS124:
             print(resistance)
             print(self.chip.read_data())
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
             print("line %s resistance is %.2f ohms (27.4 + wire)" % (line, resistance[0]))
 
             self.chip.setup_mux(self.PWR_EN, self.PG_LDO) # measuring resistance between lines PWR_EN and PG_LDO      
             line = 'PWR_EN -> PG_LDO'                   
             resistance = self.chip.read_volts(vref=2000,ave=4)
-            passed, message = check_value(resistance[0], self.targets[1][0], self.targets[1][1])
+            passed, message = check_value(resistance[0], self.passing_criteria['min_resistance'], self.passing_criteria['max_resistance'])
             if not passed:
                 all_passed = False
+                if resistance[0] <= self.passing_criteria['min_resistance']:
+                    self.comments.append('Short identified on module {} path {}'.format(self.module, line))
+                else:
+                    self.comments.append('Open identified on module {} path {}'.format(self.module, line))
             self.data[line] = [resistance[0], message]
-            self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
             print("line %s resistance is %.2f ohms (1 + wire); %s" % (line, resistance[0], message))
 
             self.chip.setup_mux(self.PG_DCDC, self.ECON_RE_Hb) # measuring resistance between lines PG_DCDC and ECON_RE_Hb
             line = 'PG_DCDC -> ECON_RE_Hb'                           
             resistance = self.chip.read_volts(vref=2000,ave=4)
-            passed, message = check_value(resistance[0], self.targets[2][0], self.targets[2][1])
+            passed, message = check_value(resistance[0], self.passing_criteria['min_resistance'], self.passing_criteria['max_resistance'])
             if not passed:
                 all_passed = False
+                if resistance[0] <= self.passing_criteria['min_resistance']:
+                    self.comments.append('Short identified on module {} path {}'.format(self.module, line))
+                else:
+                    self.comments.append('Open identified on module {} path {}'.format(self.module, line))
             self.data[line] = [resistance[0], message]
-            self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
             print("line %s resistance is %.2f ohms (1 + wire); %s" % (line, resistance[0], message))
 
             self.chip.setup_mux(self.ECON_RE_Sb, self.HGCROC_RE_Sb) # measuring resistance between lines ECON_RE_Sb and HGCROC_RE_Sb   
             line = 'ECON_RE_Sb -> HGCROC_RE_Sb'            
             resistance = self.chip.read_volts(vref=2000,ave=4)
-            passed, message = check_value(resistance[0], self.targets[3][0], self.targets[3][1])
+            passed, message = check_value(resistance[0], self.passing_criteria['min_resistance'], self.passing_criteria['max_resistance'])
             if not passed:
                 all_passed = False
+                if resistance[0] <= self.passing_criteria['min_resistance']:
+                    self.comments.append('Short identified on module {} path {}'.format(self.module, line))
+                else:
+                    self.comments.append('Open identified on module {} path {}'.format(self.module, line))
             self.data[line] = [resistance[0], message]
-            self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
             print("line %s resistance is %.2f ohms (18 + wire); %s" % (line, resistance[0], message))
 
             self.chip.set_idac_channel(self.IDAC2,13)
@@ -164,26 +195,33 @@ class module_ADS124:
             volts = self.chip.read_volts(vref=2.5, ave=4)   
 
             resistance = [ volts[0] / ((10**-6)*self.chip.get_idac_current()), volts[1] / ((10**-6) * self.chip.get_idac_current()) ]  
-            passed, message = check_value(resistance[0], self.targets[4][0], self.targets[4][1])
+            passed, message = check_value(resistance[0], self.passing_criteria['min_resistance'], self.passing_criteria['max_resistance'])
             if not passed:
                 all_passed = False
+                if resistance[0] <= self.passing_criteria['min_resistance']:
+                    self.comments.append('Short identified on module {} path {}'.format(self.module, line))
+                else:
+                    self.comments.append('Open identified on module {} path {}'.format(self.module, line))
             self.data[line] = [resistance[0], message]
-            self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
             print("line %s resistance is %.2f ohms; %s" % (line, resistance[0], message))
 
             print("Did all pass? : {}".format(all_passed))
 
             self.chip.powerdown()
 
-            return all_passed
+            return all_passed, self.comments
 
         except Exception as e:
             print(e)
             #self.conn.send(e)
-            self.conn.send("Issues running general resistance measurement, check board connections")
+            if self.conn is not None:
+                self.conn.send("Issues running general resistance measurement, check board connections")
+            self.comments.append('Unable to run test for module {}'.format(self.module))
             self.data={"Error": 1}
             self.chip.powerdown()
-            return False
+            return False, self.comments
 
 class id_ADS124:
 
@@ -202,7 +240,7 @@ class id_ADS124:
     IDAC4 = 0
     IDAC5 = 11
 
-    def __init__(self, conn, targets=None):
+    def __init__(self, conn, id_res):
         
         # Initalizing the PIPE as an attribute
         self.conn = conn
@@ -210,9 +248,13 @@ class id_ADS124:
         self.chip = ADS124(bus=3, device=3)
         self.chip.wakeup()
         self.chip.reset()
-        self.targets = [[495,505]] #placeholder
+        self.passing_criteria = {
+            'min_id_res': id_res * 0.95,
+            'max_id_res': id_res * 1.05,
+        }
         self.chip.reset_POR_flag()
         self.data = {}
+        self.comments = []
 
     def get_resistances(self, num_modules=1, east=False):
         try:
@@ -284,22 +326,27 @@ class id_ADS124:
             except:
                 resistance = [0]
             self.data[line] = resistance[0]
-            self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
-            passed, message = check_value(resistance[0], self.targets[0][0], self.targets[0][1])
+            if self.conn is not None:
+                self.conn.send("line %s resistance is %.2f ohms" % (line, resistance[0]))
+            passed, message = check_value(resistance[0], self.passing_criteria['min_id_res'], self.passing_criteria['max_id_res'])
             print("line %s resistance is %.2f ohms (1200 + wire)" % (line, resistance[0]))
             if passed:
                 all_passed = True
+            else:
+                self.comments.append('ID resistor outside of allowed range: {}'.format(resistance[0]))
 
             self.chip.powerdown()
 
-            return all_passed
+            return all_passed, self.comments
         except Exception as e:
             print(e)
-            self.conn.send(e)
-            self.conn.send("Issue running ID resistance test, check board connections")
+            if self.conn is not None:
+                self.conn.send(e)
+                self.conn.send("Issue running ID resistance test, check board connections")
+            self.comments.append('Unable to run ID resistor test')
             self.data = {"Error": 1}
             self.chip.powerdown()
-            return False
+            return False, self.comments
 
 
 class gen_resist_test(Test):
@@ -331,19 +378,26 @@ class gen_resist_test(Test):
                 self.module_chips[i] = module_ADS124(self.conn, i)
                 self.module_chips[i].data["Module"] = i+1
                 #self.conn.send("LCD ; Percent:{:3f} Test:1".format(i/float(len(self.module_chips))))
-                passed = self.module_chips[i].get_resistances()
+                passed, comments = self.module_chips[i].get_resistances()
                 #if not res_val: passed = False   
                 #elif res_val > 100 or res_val < 0.1: passed = False
                 data.update({'module ' + str(i+1): self.module_chips[i].data})
     
-        
+       
+        comments = '\n'.join(comments)
+
+        passing_criteria = self.module_chips[i].passing_criteria
+
+        data = {'test_data': data, 'passing_criteria': passing_criteria} 
+
         #self.conn.send("LCD ; Passed:{} Test:1".format(passed))
         print("Finishing test...")
-        self.conn.send("Done.") 
+        if self.conn is not None:
+            self.conn.send("Done.") 
         print('Done.')
         #self.conn.send({"pass": passed, "data": data})
         print({"pass": passed, "data": data})
-        return passed, data
+        return passed, data, comments
 
     def get_num_modules(self, path="/home/HGCAL_dev/sw/WagonTesting/static/wagonConfig.json"):
         
@@ -357,7 +411,7 @@ class gen_resist_test(Test):
 
         type_info = types_dict[subtype]
         
-        return type_info["NumMod"]
+        return len(type_info.keys()) - 1
 
 
 class id_resist_test(Test):
@@ -372,7 +426,9 @@ class id_resist_test(Test):
 
     def run_ID_test(self, **kwargs):
         
-        self.id_chip = id_ADS124(self.conn)
+        id_res = self.get_id_res()
+
+        self.id_chip = id_ADS124(self.conn, id_res)
 
 
         passed = True
@@ -380,19 +436,39 @@ class id_resist_test(Test):
         east = kwargs['east']
         data = {}
 
-        passed = self.id_chip.get_resistances(num_modules, east)
+        passed, comments = self.id_chip.get_resistances(num_modules, east)
         data.update({'wagon type chip': self.id_chip.data})
 
 
+        comments = '\n'.join(comments)
+
+        passing_criteria = self.id_chip.passing_criteria
+
+        data = {'test_data': data, 'passing_criteria': passing_criteria} 
+
         print("Sending message about passing wagon ID")
-        self.conn.send("LCD ; Passed:{} Test:2".format(passed))
-        self.conn.send("Done.")
+        if self.conn is not None:
+            #self.conn.send("LCD ; Passed:{} Test:2".format(passed))
+            self.conn.send("Done.")
         print('Done.')
         #self.conn.send({"pass": passed, "data": data})
         print({"pass": passed, "data": data})
-        return passed, data
+        return passed, data, comments
 
 
+    def get_id_res(self, path="/home/HGCAL_dev/sw/WagonTesting/static/wagonConfig.json"):
+        
+        subtype = self.info_dict["board_sn"][3:-6]
+
+        with open(path, "r") as f:
+            
+            types_dict = json.load(f)
+            
+        f.close()
+
+        type_info = types_dict[subtype]
+        
+        return type_info["IDResistor"]
 
 ###############################################################################
 

--- a/wagoneer.py
+++ b/wagoneer.py
@@ -215,6 +215,7 @@ class Wagon:
 
     def scan(self, iskip=5, conn=None):
         scan = [] 
+        print(conn)
         for delay in range(0,511, iskip):
 
             if conn is not None:


### PR DESCRIPTION
… criteria for BERT

New passing criteria for bit error rate test defined in terms of fractional eye opening. Other changes include:
- Updated fitting procedure which is more stable
- Switching from 5 phase step skip to checking every phase step (~5x slow down but necessary for the fit to converge)

Additionally, comments have been added to the 5 tests so that it is easier to understand why a test has failed. 

Finally, test results are now sent in a dictionary containing keys ('test_data', 'passing_criteria'). We will need to accommodate this new format on the wagon testing webpage (mostly just plots, but possibly a few other places).