### PR TITLE
Fixing issue with noisy walking ones (spy related)

### DIFF
--- a/run_bert.py
+++ b/run_bert.py
@@ -220,7 +220,7 @@ class BERT(Test):
                     data = np.array(self.wagon.spy(-1, 100, prnt=False)).reshape(100, -1)
                     print([hex(d) for d in data[99]])
                     cur_result = '0xff' == hex(data[99][cur_rx])
-                    zero_res = all(['0x0' == hex(d) for i, d in enumerate(data[99]) if i != cur_rx])
+                    zero_res = all([128 < int(d) for i, d in enumerate(data[99]) if i != cur_rx])
                     results[outp['Eng_Elink']] = cur_result and zero_res
 
                     if not cur_result:


### PR DESCRIPTION
Seeing some noise when setting TXs to zeros for all but one line. This is causing incorrect failure of wagons with known good mapping. 

I'm changing the passing requirement such that the lines where we expect zeros must be lower than 128 (to accommodate some random bit flips). The walking one portion of the test seems to be working as intended without noise issues.