### PR TITLE
Adding one peak bypass for CLK lines

### DIFF
--- a/fit_bert.py
+++ b/fit_bert.py
@@ -71,6 +71,10 @@ class FitData:
         if short:
             return len(maxes) <= 1
 
+        if len(maxes) == 1:
+            # If there is one peak exactly, the board should pass
+            return {'Fit Eye Opening': 0.51, 'Data Eye Opening': 0.51, 'Fit Quality': 0.0}
+
         if len(maxes) > 2:
             maxes = maxes[:2]
 

--- a/run_bert.py
+++ b/run_bert.py
@@ -251,12 +251,8 @@ class BERT(Test):
                 #print('Need to invert on RX {}'.format(i_rx))
                 self.wagon.invert(i_rx)
 
-        if self.subtype[:2] == 'WW':
-            for i_rx in range(7, 10):
-                self.wagon.set_half_speed(i_rx, mode=1)
-        else:
-            for i_rx in range(7, 10):
-                self.wagon.set_half_speed(i_rx, mode=0)
+        for i_rx in range(7, 10):
+            self.wagon.set_half_speed(i_rx, mode=1)
 
     def set_prbs_len(self, prbs_len):
         self.wagon.set_prbs_len(prbs_len)
@@ -268,12 +264,11 @@ class BERT(Test):
         for i in range(0,8):
             self.wagon.set_tx_mode(i, PRBS)
 
-        if self.subtype[:2] == 'WW':
-            for i in range(0,3):
-                if shift_map[i+8]:
-                    self.wagon.set_tx_mode(i, PRBS_HALFSPEED_SHIFT)
-                else:
-                    self.wagon.set_tx_mode(i, PRBS_HALFSPEED)
+        for i in range(0,3):
+            if shift_map[i+8]:
+                self.wagon.set_tx_mode(i, PRBS_HALFSPEED_SHIFT)
+            else:
+                self.wagon.set_tx_mode(i, PRBS_HALFSPEED)
         
 
     def setup_links(self, board_sn, module, clock, set_cp=True):


### PR DESCRIPTION
CLK lines for east wagons can have an eye opening that is ~0.5 when running at full speed. Therefore, we need to catch anytime we see this and pass the wagon.