### PR TITLE
Implementing Crossover Test

### DIFF
--- a/run_bert.py
+++ b/run_bert.py
@@ -67,6 +67,7 @@ class BERT(Test):
         self.passed = True
         self.data = {}
         
+        self.reset_zeros()
         res_elink, comments = self.elink_continuity_test(comments)
 
         print(res_elink)

--- a/run_iic_check.py
+++ b/run_iic_check.py
@@ -6,6 +6,7 @@ import HwInterface.mcp23009 as mcp23009
 from Test import Test 
 from math import fabs
 from multiprocessing import Pipe
+from pathlib import Path
 import sys
 
 import time, json
@@ -176,14 +177,17 @@ class IIC_Check(Test):
         print({"pass": passed, "data": data})
         return passed, data, comments
 
-    def get_num_mod(self, cfg_path = "/home/HGCAL_dev/sw/WagonTesting/static/wagonConfig.json"):
+    def get_num_mod(self, cfg_path = Path(__file__).parent / "static" / "wagonConfig.json"):
         self.subtype = self.info_dict["board_sn"][3:-6]
 
         with open(cfg_path, "r") as json_file:
             data = json.load(json_file)
         json_file.close()
 
-        return len(data[self.subtype].keys()) - 1
+        if "ModX" in data[self.subtype].keys():
+            return len(data[self.subtype].keys()) - 1
+        else:
+            return len(data[self.subtype].keys()) - 2
 
 
 if __name__ == '__main__':

--- a/run_tests.py
+++ b/run_tests.py
@@ -29,7 +29,7 @@ def run_tests(test_info):
 #sn = sys.argv[1]
 
 #test_info = {'board_sn': str(sn), 'tester': "Jocie"}
-test_info = {'board_sn': '320WE20B1000001', 'tester': "Bryan"}
+test_info = {'board_sn': '320WE10A1000001', 'tester': "Bryan"}
 run_tests(test_info)
 
 #print("Running tests for east wagon")

--- a/static/txrx_east.json
+++ b/static/txrx_east.json
@@ -21,7 +21,8 @@
         {"num": 8, "link": "CTL2"},
         {"num": 9, "link": "CTL3"},
         {"num": 10, "link": ""},
-        {"num": 11, "link": ""},
-        {"num": 12, "link": ""}
+        {"num": 11, "link": "XING0"},
+        {"num": 12, "link": "XING1"},
+        {"num": 13, "link": "XING2"}
     ]
 }

--- a/static/txrx_west.json
+++ b/static/txrx_west.json
@@ -21,7 +21,8 @@
         {"num": 8, "link": "CTL2"},
         {"num": 9, "link": "CTL3"},
         {"num": 10, "link": ""},
-        {"num": 11, "link": ""},
-        {"num": 12, "link": ""}
+        {"num": 11, "link": "XING0"},
+        {"num": 12, "link": "XING1"},
+        {"num": 13, "link": "XING2"}
     ]
 }

--- a/static/wagonConfig.json
+++ b/static/wagonConfig.json
@@ -41,7 +41,33 @@
                     "Invert": 0
                 }
             }
-        }
+        },
+	"ModX": {
+	    "Inputs": {
+		"0": {
+		    "Eng_Elink": "XING0",
+		    "Mod_Elink": "Crossover",
+                    "Invert": 0
+		},
+		"1": {
+		    "Eng_Elink": "XING1",
+		    "Mod_Elink": "Crossover",
+                    "Invert": 0
+		}
+	   },
+	   "Outputs": {
+		"0": {
+		    "Eng_Elink": "TRIG1",
+		    "Mod_Elink": "Crossover",
+                    "Invert": 0
+		},
+		"1": {
+		    "Eng_Elink": "TRIG0",
+		    "Mod_Elink": "Crossover",
+                    "Invert": 0
+		}
+	   }
+	}
     },
     "WE10B1": {
         "IDResistor": 6340,

--- a/wagon_rtd.py
+++ b/wagon_rtd.py
@@ -7,6 +7,8 @@ from datetime import datetime
 import time
 import json
 
+from pathlib import Path
+
 
 def parse_ID(ID): #likely will come from an imported utility class, right now just return a basic configuration
     num_modules = 1
@@ -399,7 +401,7 @@ class gen_resist_test(Test):
         print({"pass": passed, "data": data})
         return passed, data, comments
 
-    def get_num_modules(self, path="/home/HGCAL_dev/sw/WagonTesting/static/wagonConfig.json"):
+    def get_num_modules(self, path=Path(__file__).parent / "static" / "wagonConfig.json"):
         
         subtype = self.info_dict["board_sn"][3:-6]
 
@@ -410,8 +412,11 @@ class gen_resist_test(Test):
         f.close()
 
         type_info = types_dict[subtype]
-        
-        return len(type_info.keys()) - 1
+       
+        if "ModX" in type_info.keys():
+            return len(type_info.keys()) - 2
+        else:
+            return len(type_info.keys()) - 1 
 
 
 class id_resist_test(Test):
@@ -460,7 +465,7 @@ class id_resist_test(Test):
         return passed, data, comments
 
 
-    def get_id_res(self, path="/home/HGCAL_dev/sw/WagonTesting/static/wagonConfig.json"):
+    def get_id_res(self, path=Path(__file__).parent / "static" / "wagonConfig.json"):
         
         subtype = self.info_dict["board_sn"][3:-6]
 

--- a/wagoneer.py
+++ b/wagoneer.py
@@ -297,6 +297,12 @@ class Wagon:
         self.wagon.getNode("CTL.RESET_GENERAL").read()
         self.dispatch()
 
+    def get_nrx(self):
+        return int(self.nrx)
+
+    def get_ntx(self):
+        return int(self.ntx)
+
 def cleanup(val):
    cval=0
    for i in range(0,8):


### PR DESCRIPTION
Note: This will break things until we have the updated version of the wagonConfig.json file with appropriate input crossovers listed. 

BERT test now supports crossover link testing. The BERT test now decided whether to load the xoverin or xoverout version of the firmware based on the crossovers specified in the configuration file. Input crossovers are specified using the "ModX" key and are appropriately mapped to the correct TX/RX pair in the firmware. Output crossovers are treated similarly to normal TRIG elinks and can be tested using the correct configuration of the crosspoint. However, we will not be able to test XING elinks which are mapped to the third input of the crosspoint since we would need some crossovers to behave as TXs and some to behave as RXs in this case. 