### PR TITLE
BERT Fix for Flowers

### DIFF
--- a/run_bert.py
+++ b/run_bert.py
@@ -444,7 +444,7 @@ class BERT(Test):
             os.system('sudo fw-loader load wagon-tester-kria-xoverout')
 
         self.wagon = Wagon()
-        scan_mask = [0] * self.wagon.get_nrx()
+        scan_mask = [0] * (self.wagon.get_nrx()+1)
 
 
         link_names = {}


### PR DESCRIPTION
The Flower (WE10B1) subtypes have three crossing links which are all "outputs" from the perspective of the crosspoint. Therefore, we need to make sure that all three XING RXs are being read out in the BER test.